### PR TITLE
removed the comments about se-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,43 +51,6 @@ sudo yum install epel-release
 sudo yum install virt-manager libvirt qemu qemu-system-x86
 ```
 
-### Possibly Required
-By default *CentOS* is using *SELinux*, so additional configuration is required to work with `libvirt`.
-
-#### Setup SSH access for `libvirt`
-1. Create the user group:
-```bash
-sudo groupadd libvirt
-```
-
-2. Update the `libvirt` configuration in `/etc/libvirt/libvirtd.conf`. Uncomment these two lines:
-```bash
-#unix_sock_group = "libvirt"
-#unix_sock_rw_perms = "0770"
-```
-
-3. Restart the service:
-```bash
-sudo service libvirtd restart
-```
-
-4. Manage group membership - Add the desired users to this user group: 
-```bash
-sudo usermod -G libvirt -a *username*
-```
-
-
-#### Configure management access via PolicyKit
-Create a new policy file `/etc/polkit-1/localauthority/50-local.d/50-de.est.libvirt-remote-access.pkla` with the following content:
-```
-[libvirt Management Access]
-Identity=unix-group:libvirt
-Action=org.libvirt.unix.manage
-ResultAny=yes
-ResultInactive=yes
-ResultActive=yes
-```
-
 ### Install Vagrant 1.7+
 Download from [website](http://www.vagrantup.com/downloads.html), then:
 ```
@@ -108,7 +71,7 @@ Reboot the system
 
 ## Gotchas
 
-*Vagrant* usually stores machine images underneath `/var`, so please make sure that you have at least 30GB of free space on the file system that is hosting `/var`. 
+*Vagrant* usually stores machine images underneath `/var`, so please make sure that you have at least 30GB of free space on the file system that is hosting `/var`.
 
 
 ## Ready... Set... Go...


### PR DESCRIPTION
I removed the documentation about SE-linux for CentOS

It was some documentation from Florian. It is not absolutely needed. Florian experienced some performance improvements. 

In general the documentation was intended only to be used internally. It is not cleaned up enough to publish it. So, I removed it
